### PR TITLE
[feature] add Menu model, update POST methods for Restaurants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 .idea/
 
 # log, pid, etc..
-log/
+logs/
 run/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Snakebite  
 [![Build Status](https://travis-ci.org/wheresmybento/snakebite.svg?branch=master)](https://travis-ci.org/wheresmybento/snakebite)
-[![Coverage Status](https://img.shields.io/coveralls/wheresmybento/snakebite.svg)](https://coveralls.io/r/wheresmybento/snakebite)
 
 Snakebite is built with Python, and more specifically with Falcon framework and MongoEngine (python client for MongoDB).
 

--- a/snakebite/constants.py
+++ b/snakebite/constants.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
+TOKYO_GEOLOCATION = (139.710388, 35.673343)

--- a/snakebite/controllers/hooks/__init__.py
+++ b/snakebite/controllers/hooks/__init__.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from snakebite.helpers.json import map_query
 from snakebite.libs.error import HTTPBadRequest, HTTPNotAcceptable
 import mongoengine as mongo
-import json
 from bson import json_util
 import colander
 
@@ -36,7 +35,7 @@ def deserialize(req, res, resource, schema=None):
         if not stream:
             return
 
-        json_body = json.loads(stream)
+        json_body = json_util.loads(stream)
 
         if schema:
             try:
@@ -79,12 +78,11 @@ def serialize(req, res, resource):
     def _to_json(obj):
         # base cases:
         if isinstance(obj, mongo.Document):
-            return obj._data
-        if type(obj) in [int, str]:
-            return obj
+            return json_util.loads(obj.to_json())
         if isinstance(obj, dict):
             return {k: _to_json(v) for k, v in obj.iteritems()}
         if isinstance(obj, mongo.queryset.queryset.QuerySet):
             return [_to_json(item) for item in obj]
+        return obj
 
     res.body = json_util.dumps(_to_json(res.body))

--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -27,6 +27,17 @@ class Collection(object):
         res.status = falcon.HTTP_200
         query_params = req.params.get('query')
 
+        # update query filters
+        updated_params = {}
+
+        for item in ['name', 'description', 'menus.name']:
+            if item in query_params:
+                item_val = query_params.pop(item)
+                updated_params['{}__icontains'.format(item)] = item_val
+
+        # TODO: filter by geolocation
+        query_params.update(updated_params)
+
         restaurants = Restaurant.objects(**query_params)
         res.body = {'items': restaurants, 'count': len(restaurants)}
 

--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -4,13 +4,13 @@ from __future__ import absolute_import
 import falcon
 import logging
 from snakebite.controllers.hooks import deserialize, serialize
-from snakebite.controllers.schema.restaurant import CreateRestaurantSchema
-from snakebite.models.restaurant import Restaurant
+from snakebite.controllers.schema.restaurant import RestaurantSchema
+from snakebite.models.restaurant import Restaurant, Menu
 
 
 # -------- BEFORE_HOOK functions
 def deserialize_create(req, res, resource):
-    return deserialize(req, res, resource, schema=CreateRestaurantSchema())
+    return deserialize(req, res, resource, schema=RestaurantSchema())
 
 # -------- END functions
 
@@ -37,7 +37,11 @@ class Collection(object):
         data = req.params.get('body')
 
         # save to DB
+        menu_data = data.pop('menus')  # extract info meant for menus
+
         restaurant = Restaurant(**data)
+        restaurant.menus = [Menu(**menu) for menu in menu_data]
+
         restaurant.save()
 
         res.body = restaurant

--- a/snakebite/controllers/schema/common.py
+++ b/snakebite/controllers/schema/common.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import colander
+
+
+class Images(colander.SequenceSchema):
+    image = colander.SchemaNode(colander.String(), validator=colander.url)

--- a/snakebite/controllers/schema/common.py
+++ b/snakebite/controllers/schema/common.py
@@ -2,7 +2,13 @@
 
 from __future__ import absolute_import
 import colander
+from snakebite.constants import TOKYO_GEOLOCATION
 
 
 class Images(colander.SequenceSchema):
     image = colander.SchemaNode(colander.String(), validator=colander.url)
+
+
+class Geolocation(colander.TupleSchema):
+    longitude = colander.SchemaNode(colander.Float(), validator=colander.Range(-180, 180), missing=TOKYO_GEOLOCATION[0])
+    latitude = colander.SchemaNode(colander.Float(), validator=colander.Range(-90, 90), missing=TOKYO_GEOLOCATION[1])

--- a/snakebite/controllers/schema/restaurant.py
+++ b/snakebite/controllers/schema/restaurant.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 import colander
 import decimal
-from snakebite.controllers.schema.common import Images
+from snakebite.controllers.schema.common import Images, Geolocation
 from snakebite.helpers.schema import CommaList, Currency
 
 
@@ -24,5 +24,6 @@ class RestaurantSchema(colander.MappingSchema):
     address = colander.SchemaNode(colander.String())
     email = colander.SchemaNode(colander.String(), validator=colander.Email(), missing='')
     description = colander.SchemaNode(colander.String(), missing='')
+    geolocation = Geolocation()
     tags = colander.SchemaNode(CommaList(), missing='')
     menus = Menus()

--- a/snakebite/controllers/schema/restaurant.py
+++ b/snakebite/controllers/schema/restaurant.py
@@ -2,12 +2,27 @@
 
 from __future__ import absolute_import
 import colander
-from snakebite.helpers.schema import CommaList
+import decimal
+from snakebite.controllers.schema.common import Images
+from snakebite.helpers.schema import CommaList, Currency
 
 
-class CreateRestaurantSchema(colander.MappingSchema):
+class MenuSchema(colander.MappingSchema):
+    name = colander.SchemaNode(colander.String())
+    price = colander.SchemaNode(colander.Decimal(quant='1.00', rounding=decimal.ROUND_UP))  # 2dp, rounded up
+    currency = colander.SchemaNode(Currency(), validator=Currency.is_valid, missing='JPY')
+    images = Images()
+    tags = colander.SchemaNode(CommaList(), missing='')
+
+
+class Menus(colander.SequenceSchema):
+    menu = MenuSchema()
+
+
+class RestaurantSchema(colander.MappingSchema):
     name = colander.SchemaNode(colander.String())
     address = colander.SchemaNode(colander.String())
     email = colander.SchemaNode(colander.String(), validator=colander.Email(), missing='')
     description = colander.SchemaNode(colander.String(), missing='')
     tags = colander.SchemaNode(CommaList(), missing='')
+    menus = Menus()

--- a/snakebite/helpers/schema.py
+++ b/snakebite/helpers/schema.py
@@ -25,3 +25,26 @@ class CommaIntList(CommaList):
         for item in list:
             if not isinstance(item, int):
                 raise colander.Invalid(node, error_msg)
+
+
+class Currency(object):
+
+    currency_map = {
+        'JPY': u'¥',
+        'USD': u'$',
+        'GBP': u'£',
+        'SGD': u'SGD$'
+    }
+
+    def deserialize(self, node, cstruct):
+        if not cstruct or cstruct is colander.null:
+            return 'JPY'
+        return cstruct[:3]  # trim to first 3 characters
+
+    @staticmethod
+    def is_valid(node, value):
+        currency_list = Currency.currency_map.keys()
+        error_msg = '%r is not a supported currency. Current supported currencies are %r' % (value, currency_list)
+
+        if value not in currency_list:
+            raise colander.Invalid(node, error_msg)

--- a/snakebite/helpers/schema.py
+++ b/snakebite/helpers/schema.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import colander
 
 

--- a/snakebite/models/restaurant.py
+++ b/snakebite/models/restaurant.py
@@ -11,7 +11,7 @@ class Restaurant(mongo.DynamicDocument):
     geolocation = mongo.PointField()
     description = mongo.StringField()
     tags = mongo.ListField()
-    menus = mongo.SortedListField(mongo.EmbeddedDocumentField(Menu), ordering='rating')
+    menus = mongo.SortedListField(mongo.EmbeddedDocumentField('Menu'), ordering='rating')
 
     @property
     def location(self):
@@ -22,7 +22,8 @@ class Restaurant(mongo.DynamicDocument):
 
 
 class Menu(mongo.DynamicEmbeddedDocument):
-    price = mongo.FloatField(required=True)
+    name = mongo.StringField()
+    price = mongo.DecimalField(min_value=0, required=True)  # defaults to 2 dp, rounded up
     currency = mongo.StringField(required=True, default='JPY')
     rating = mongo.FloatField(min_value=0, max_value=5, default=0)  # current avg rating
     images = mongo.ListField(mongo.URLField())  # list of urls

--- a/snakebite/models/restaurant.py
+++ b/snakebite/models/restaurant.py
@@ -4,13 +4,14 @@ from __future__ import absolute_import
 import mongoengine as mongo
 
 
-class Restaurant(mongo.Document):
+class Restaurant(mongo.DynamicDocument):
     name = mongo.StringField(required=True)
     address = mongo.StringField(required=True)
     email = mongo.EmailField(required=True)
     geolocation = mongo.PointField()
     description = mongo.StringField()
     tags = mongo.ListField()
+    menus = mongo.SortedListField(mongo.EmbeddedDocumentField(Menu), ordering='rating')
 
     @property
     def location(self):
@@ -18,3 +19,11 @@ class Restaurant(mongo.Document):
             'address': self.address,
             'geolocation': self.geolocation,
         }
+
+
+class Menu(mongo.DynamicEmbeddedDocument):
+    price = mongo.FloatField(required=True)
+    currency = mongo.StringField(required=True, default='JPY')
+    rating = mongo.FloatField(min_value=0, max_value=5, default=0)  # current avg rating
+    images = mongo.ListField(mongo.URLField())  # list of urls
+    tags = mongo.ListField()

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -5,6 +5,7 @@ from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import restaurant
 from snakebite.models.restaurant import Restaurant
+from snakebite.constants import TOKYO_GEOLOCATION
 import json
 
 
@@ -56,7 +57,13 @@ class TestRestaurantCollectionPost(testing.TestBase):
         self.srmock = testing.StartResponseMock()
 
     def get_mock_restaurant(self, **kwargs):
-        base_restaurant = {"name": "KFC", "address": "ueno", "email": "kf@c.com", "menus": []}
+        base_restaurant = {
+            "name": "KFC",
+            "address": "ueno",
+            "email": "kf@c.com",
+            "menus": [],
+            "geolocation": TOKYO_GEOLOCATION
+        }
         base_restaurant.update(kwargs)
         return base_restaurant
 
@@ -80,24 +87,32 @@ class TestRestaurantCollectionPost(testing.TestBase):
             {
                 'data': json.dumps(restaurant1),
                 'expected': {
-                    "name": "First Kitchen", "address": "ueno", "description": "",
-                    "email": "kf@c.com", "tags": [],
+                    "name": "First Kitchen",
+                    "address": "ueno",
+                    "description": "",
+                    "geolocation": {'type': 'Point', 'coordinates': list(TOKYO_GEOLOCATION)},
+                    "email": "kf@c.com",
+                    "tags": [],
                     "menus": []
                 }
             },
             {
                 'data': json.dumps(restaurant2),
                 'expected': {
-                    "name": "KFC", "address": "ueno", "description": "",
-                    "email": "kf@c.com", "tags": [],
+                    "name": "KFC",
+                    "address": "ueno",
+                    "description": "",
+                    "geolocation": {'type': 'Point', 'coordinates': list(TOKYO_GEOLOCATION)},
+                    "email": "kf@c.com",
+                    "tags": [],
                     "menus": [
                         {
-                             "name": "menu A",
-                             "price": 100.00,
-                             "currency": "JPY",
-                             "tags": [],
-                             "images": ['http://kfc.com/1.jpg'],
-                             "rating": 0.0
+                            "name": "menu A",
+                            "price": 100.00,
+                            "currency": "JPY",
+                            "tags": [],
+                            "images": ['http://kfc.com/1.jpg'],
+                            "rating": 0.0
                         },
                         {
                             "name": "menu B",

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -55,27 +55,60 @@ class TestRestaurantCollectionPost(testing.TestBase):
         self.api.add_route('/restaurants', self.resource)
         self.srmock = testing.StartResponseMock()
 
+    def get_mock_restaurant(self, **kwargs):
+        base_restaurant = {"name": "KFC", "address": "ueno", "email": "kf@c.com", "menus": []}
+        base_restaurant.update(kwargs)
+        return base_restaurant
+
+    def get_mock_menu(self, **kwargs):
+        base_menu = {"name": "some menu", "price": 100.00, "currency": 'JPY', 'images': ['http://kfc.com/1.jpg']}
+        base_menu.update(kwargs)
+        return base_menu
+
     def tearDown(self):
         Restaurant.objects.delete()
 
     def test_collection_on_post(self):
 
+        restaurant1 = self.get_mock_restaurant(name="First Kitchen")  # with no menus (not good!)
+
+        restaurant2 = self.get_mock_restaurant()
+        menus2 = [self.get_mock_menu(name="menu A"), self.get_mock_menu(name="menu B")]
+        restaurant2.update({'menus': menus2})
+
         tests = [
             {
-                'data': '{"name": "KFC", "address": "ueno", "email": "kf@c.com"}',
-                'expected': {"name": "KFC", "address": "ueno", "description": "",
-                             "email": "kf@c.com", "tags": [], "geolocation": None}
+                'data': json.dumps(restaurant1),
+                'expected': {
+                    "name": "First Kitchen", "address": "ueno", "description": "",
+                    "email": "kf@c.com", "tags": [],
+                    "menus": []
+                }
             },
             {
-                'data': '{"name": "KFC", "address": "ueno", "tags": "a,b,c", "email": "kf@c.com"}',
-                'expected': {"name": "KFC", "address": "ueno", "description": "",
-                             "email": "kf@c.com", "tags": ["a", "b", "c"], "geolocation": None}
-            },
-            {
-                'data': '{"name": "KFC", "address": "ueno", "description": "KFC desu", '
-                        '"email": "kf@c.com", "tags": "a,b,c"}',
-                'expected': {"name": "KFC", "address": "ueno", "description": "KFC desu",
-                             "email": "kf@c.com", "tags": ["a", "b", "c"], "geolocation": None}
+                'data': json.dumps(restaurant2),
+                'expected': {
+                    "name": "KFC", "address": "ueno", "description": "",
+                    "email": "kf@c.com", "tags": [],
+                    "menus": [
+                        {
+                             "name": "menu A",
+                             "price": 100.00,
+                             "currency": "JPY",
+                             "tags": [],
+                             "images": ['http://kfc.com/1.jpg'],
+                             "rating": 0.0
+                        },
+                        {
+                            "name": "menu B",
+                            "price": 100.00,
+                            "currency": "JPY",
+                            "tags": [],
+                            "images": ['http://kfc.com/1.jpg'],
+                            "rating": 0.0
+                        }
+                    ]
+                }
             }
         ]
 

--- a/snakebite/tests/test_models.py
+++ b/snakebite/tests/test_models.py
@@ -2,27 +2,78 @@
 
 from __future__ import absolute_import
 from falcon import testing
-from snakebite.models.restaurant import Restaurant
+from snakebite.models.restaurant import Restaurant, Menu
 
 
 class TestRestaurant(testing.TestBase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.restaurants = [
-            {'dict': {'name': 'a', 'description': 'desc A', 'email': 'a@b.com', 'address': 'tokyo', 'tags': []}},
-            {'dict': {'name': 'b', 'description': 'desc B', 'email': 'b@a.com', 'address': 'kyoto', 'tags': ['b']}}
+    def setUp(self):
+        self.restaurants = [
+            {
+                'dict': {
+                    'name': 'a',
+                    'description': 'desc A',
+                    'email': 'a@b.com',
+                    'address': 'tokyo',
+                    'tags': [],
+                    'menus': [
+                        {
+                            'name': 'menu A',
+                            'price': 800.00,
+                            'currency': 'JPY',
+                            'rating': 0,
+                            'images': [
+                                'http://benri.jp/1.jpg',
+                                'http://benri.jp/2.jpg'
+                            ],
+                            'tags': []
+                        },
+                        {
+                            'name': 'menu B',
+                            'price': 650.00,
+                            'currency': 'JPY',
+                            'rating': 4,
+                            'images': [
+                                'http://benri.jp/3.jpg'
+                            ],
+                            'tags': []
+                        }
+                    ]
+                }
+            },
+            {
+                'dict': {
+                    'name': 'b',
+                    'description': 'desc B',
+                    'email': 'b@a.com',
+                    'address': 'kyoto',
+                    'tags': ['b'],
+                    'menus': [
+                        {
+                            'name': 'menu ABC',
+                            'price': 1000.00,
+                            'currency': 'JPY',
+                            'rating': 4,
+                            'images': [
+                                'http://benri.jp/5.jpg'
+                            ],
+                            'tags': []
+                        }
+                    ]
+                }
+            }
         ]
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         Restaurant.objects.delete()
 
     def test_init(self):
 
-        for r in TestRestaurant.restaurants:
+        for r in self.restaurants:
             attributes = r['dict']
+            menu_attrs = attributes.pop('menus')
             restaurant = Restaurant(**attributes)
+            restaurant.menus = [Menu(**attrs) for attrs in menu_attrs]
 
             for property, value in attributes.iteritems():
                 self.assertEquals(getattr(restaurant, property), value)
@@ -34,12 +85,16 @@ class TestRestaurant(testing.TestBase):
                 }
 
                 self.assertDictEqual(restaurant.location, expected_location)
+                self.assertIsNotNone(restaurant.menus)
 
     def test_save(self):
-        for i, r in enumerate(TestRestaurant.restaurants):
+        for i, r in enumerate(self.restaurants):
             attributes = r['dict']
+            menu_attrs = attributes.pop('menus')
             restaurant = Restaurant(**attributes)
+            restaurant.menus = [Menu(**attrs) for attrs in menu_attrs]
             restaurant.save()
+            self.assertEquals(len(restaurant.menus), len(menu_attrs))
             self.assertEquals(len(Restaurant.objects), i+1)
 
     def test_remove(self):


### PR DESCRIPTION
story:

> As a Restaurant Owner, I want to be able to add menus when creating my restaurant in one action so that I dont have to add Menus **only** after creating my restaurant.

issues:
- https://github.com/wheresmybento/snakebite/issues/9

changes:
- added Menu model (as an Embedded Document)
- updated all models to DynamicDocument or DynamicEmbeddedDocument instead [allowing flexibility](https://mongoengine-odm.readthedocs.org/guide/defining-documents.html#dynamic-document-schemas)
- added colander Schemas for Menu, and updated colander Schema for Restaurant (linking them up)
- updated POST requests on Restaurants so that users can create a restaurant with menus right away
- refactored `serialize` hook so that serializing to JSON is now more robust (cover Embedded Documents)
- improved test cases, updated tests
- improved tests
- remove coveralls.io badge for now


## TODO

- improve test cases on GET requests
- add filtering mechanism on GET response
