### PR TITLE
[chore] update procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn manage:snakebite.app
+web: bash web.sh

--- a/web.sh
+++ b/web.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$SNAKEBITE" == "CMS" ]; then
+  node ui/bin/www
+else
+  gunicorn manage:snakebite.app
+fi


### PR DESCRIPTION
> story: as dev team, I want to be able to deploy both Snakebite API and Snakebite CMS (UI) to Heroku from the same repository so that we can better manage consistency

## background
The *easy* way would have been to separate the CMS and API server to 2 different repositories and deploy into Heroku. However this only makes deployment to Heroku easy but it doesnt make sense to really separate the UI from the API since the UI is just a subset.

updates:
- update Procfile such that Heroku looks for the $SNAKEBITE env variable (if "CMS"; then deploy the UI; else deploy our API server)
- API server is located at http://snakebite.herokuapp.com while CMS server will be located at http://snakebite-ui.herokuapp.com