### PR TITLE
[feature] add GET /tags endpoint

### DIFF
--- a/snakebite/__init__.py
+++ b/snakebite/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 from mongoengine import connection
 from logging.handlers import TimedRotatingFileHandler
-from snakebite.controllers import restaurant
+from snakebite.controllers import restaurant, tag
 from snakebite.constants import DATETIME_FORMAT
 
 
@@ -31,6 +31,7 @@ class SnakeBite(object):
         # load routes
         self.app.add_route('/restaurants', restaurant.Collection())
         self.app.add_route('/restaurants/{id}', restaurant.Item())
+        self.app.add_route('/tags', tag.Collection())
 
     def cors_middleware(self):
         """

--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -29,10 +29,14 @@ class Collection(object):
         res.status = falcon.HTTP_200
         query_params = req.params.get('query')
 
-        # get pagination limits
-        start = int(query_params.pop('start', 0))
-        limit = int(query_params.pop('limit', 20))
-        end = start + limit
+        try:
+            # get pagination limits
+            start = int(query_params.get('start', 0))
+            limit = int(query_params.get('limit', 20))
+            end = start + limit
+        except ValueError as e:
+            raise HTTPBadRequest(title='Invalid Value',
+                                 description='Invalid arguments in URL query:\n{}'.format(e.message))
 
         # temp dict for updating query filters
         updated_params = {}

--- a/snakebite/controllers/tag.py
+++ b/snakebite/controllers/tag.py
@@ -31,5 +31,5 @@ class Collection(object):
                                  description='Invalid arguments in URL query:\n{}'.format(e.message))
 
         tag_freqs = Restaurant.objects.item_frequencies('tags', normalize=True)
-        tags = sorted(tag_freqs.items(), key=itemgetter(1), reverse=True)[start:end]
+        tags = sorted(tag_freqs.iteritems(), key=itemgetter(1), reverse=True)[start:end]
         res.body = {'items': tags, 'count': len(tags)}

--- a/snakebite/controllers/tag.py
+++ b/snakebite/controllers/tag.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import falcon
+import logging
+from operator import itemgetter
+from snakebite.controllers.hooks import deserialize, serialize
+from snakebite.models.restaurant import Restaurant
+from snakebite.libs.error import HTTPBadRequest
+
+logger = logging.getLogger(__name__)
+
+
+class Collection(object):
+    def __init__(self):
+        pass
+
+    @falcon.before(deserialize)
+    @falcon.after(serialize)
+    def on_get(self, req, res):
+        res.status = falcon.HTTP_200
+        query_params = req.params.get('query')
+
+        try:
+            # get pagination limits
+            start = int(query_params.get('start', 0))
+            limit = int(query_params.get('limit', 20))
+            end = start + limit
+        except ValueError as e:
+            raise HTTPBadRequest(title='Invalid Value',
+                                 description='Invalid arguments in URL query:\n{}'.format(e.message))
+
+        tag_freqs = Restaurant.objects.item_frequencies('tags', normalize=True)
+        tags = sorted(tag_freqs.items(), key=itemgetter(1), reverse=True)[start:end]
+        res.body = {'items': tags, 'count': len(tags)}

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -42,7 +42,9 @@ class TestRestaurantCollectionGet(testing.TestBase):
             {'query_string': 'tags=x&name=a', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'tags=x&name=c', 'expected': {"status": 200, "count": 0}},
             {'query_string': 'geolocation=139.731443,35.662836', 'expected': {"status": 200, "count": 1}},
-            {'query_string': 'geolocation=ab,cd', 'expected': {"status": 400}}
+            {'query_string': 'geolocation=ab,cd', 'expected': {"status": 400}},
+            {'query_string': 'start=2&limit=1', 'expected': {"status": 200, "count": 0}},
+            {'query_string': 'start=1limit=1', 'expected': {"status": 400}}
         ]
         for t in tests:
             res = self.simulate_request('/restaurants',

--- a/snakebite/tests/controllers/test_tag.py
+++ b/snakebite/tests/controllers/test_tag.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from falcon import testing
+from snakebite.tests import get_test_snakebite
+from snakebite.controllers import tag
+from snakebite.models.restaurant import Restaurant
+import json
+
+
+class TestRestaurantCollectionGet(testing.TestBase):
+
+    def setUp(self):
+        self.resource = tag.Collection()
+        self.api = get_test_snakebite().app
+
+        self.api.add_route('/tags', self.resource)
+        self.srmock = testing.StartResponseMock()
+        self.tags = ['buzzword', 'hipster', 'trending', 'barely trending', 'classic', 'safe', 'weird', 'regrettable']
+
+        for i in range(len(self.tags)):
+            r = Restaurant(name='restaurant #{}'.format(i), description='desc', email='hello@d.com',
+                           address='Earth', tags=[], geolocation=[1, 1])
+            r.tags = self.tags[:-i] if i else self.tags  # first restaurant has more tags than the next
+            r.save()
+
+    def tearDown(self):
+        Restaurant.objects.delete()
+
+    def test_collection_on_get(self):
+
+        tags = self.tags
+
+        tests = [
+            {'query_string': '', 'expected': {"status": 200, "count": len(tags), "tags": tags}},
+            {'query_string': 'limit=3', 'expected': {"status": 200, "count": 3, "tags": tags[:3]}},
+            {'query_string': 'start=3&limit=4', 'expected': {"status": 200, "count": 4, "tags": tags[3:3+4]}},
+            {'query_string': 'start=1limit=1', 'expected': {"status": 400}}
+        ]
+        for t in tests:
+            res = self.simulate_request('/tags',
+                                        query_string=t['query_string'],
+                                        method='GET',
+                                        headers={'accept': 'application/json'})
+
+            self.assertTrue(isinstance(res, list))
+            body = json.loads(res[0])
+            self.assertTrue(isinstance(body, dict))
+
+            if t['expected']['status'] != 200:  # expected erroneous requests
+                self.assertNotIn('count', body.keys())
+                self.assertIn('title', body.keys())
+                self.assertIn('description', body.keys())
+                continue
+
+            self.assertListEqual(["count", "items"], sorted(body.keys()))
+            self.assertEqual(body['count'], t['expected']['count'])
+            result_tags = [tag[0] for tag in body['items']]
+            self.assertListEqual(result_tags, t['expected']['tags'])


### PR DESCRIPTION
> story: As a frontend developer, I want an endpoint that can tell me the most popular `tags` currently in the database so that I can use this result to suggest searches for user

This PR adds a new endpoint `GET /tags` where you can obtain a list of tags sorted by most popular. It also returns the frequency in which the tags appears. For instance, a tag `beef` of frequency **0.8** meant that 80% of all tags are all `beef`

You can have additional arguments to limit / filter results.

| query arguments | remarks | default |
| ------- | ------ | ------ |
| start |  offset, zero-indexed, e.g., to start from second most popular tag, use `/tags?start=1` | 0 |
| limit | limit size of returned result, e.g., to get only 5 most popular tags, use `/tags?limit=5` | 20 |


## Example

> we want to get top 3 most popular tags:

request: `/tags?limit=3` or `/tags?start=0&limit=3`

response:
```
{
    "count": 3,
    "items": [
        ['beef', 0.7],
        ['chicken', 0.1],
        ['fish', 0.1]
    ]
}
```

